### PR TITLE
Fix multiword notifications on notify-send

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,3 +1,8 @@
+= This is just a fork
+
+This is a fork of https://github.com/fnando/notifier, whose goal is to
+solve a bug in notify-send and multiword/multiline messages.
+
 = Notifier
 
 Send system notifications on several platforms with a simple and unified API. Currently supports:

--- a/lib/notifier/notify_send.rb
+++ b/lib/notifier/notify_send.rb
@@ -8,7 +8,7 @@ module Notifier
 
     def notify(options)
       Thread.new do
-        `notify-send -i #{options[:image]} #{options[:title]} \"#{options[:message]}\"`
+        `notify-send -i #{options[:image]} "#{options[:title]}" "#{options[:message]}"`
       end
     end
   end


### PR DESCRIPTION
`notify-send` expects two arguments: the title and message - it doesn't concatenate all arguments. That's why it's required to surround the title as well as message with quotes.

Let me know if the patch is OK, I can tweak it, but from some quick testing locally it seems to work.
