### PR TITLE
Cleanup warning

### DIFF
--- a/lib/notifier.rb
+++ b/lib/notifier.rb
@@ -35,7 +35,7 @@ module Notifier
   end
 
   def from_name(name)
-    notifier = const_get(classify(name.to_s))
+    const_get(classify(name.to_s))
   rescue Exception
     nil
   end


### PR DESCRIPTION
I removed an unused variable that was causing a warning. Not a big deal for sure, but since there's a chance this will get required while running tests it's nice to keep it warning free.
