### PR TITLE
Growl notifier now works if image option is not supplied

### DIFF
--- a/lib/notifier/growl.rb
+++ b/lib/notifier/growl.rb
@@ -14,7 +14,7 @@ module Notifier
       command = [
         "growlnotify",
         "--name", "test_notifier",
-        "--image", options[:image],
+        "--image", (options[:image] || ''),
         "--priority", "2",
         "--message", options[:message],
         options[:title]


### PR DESCRIPTION
Very simple, now if you don't supply the image option, a notification will still appear when you are using the growl backend.

Previously, `Notifier.notify(:message => "some message", :title => "Some title")` would fail with growl.