### PR TITLE
Redirect `which` stdout and stderr to /dev/null

### DIFF
--- a/lib/notifier/kdialog.rb
+++ b/lib/notifier/kdialog.rb
@@ -3,7 +3,7 @@ module Notifier
     extend self
 
     def supported?
-      Notifier.os?(/(linux|freebsd)/) && `which kdialog > /dev/null` && $? == 0
+      Notifier.os?(/(linux|freebsd)/) && `which kdialog &> /dev/null` && $? == 0
     end
 
     def notify(options)

--- a/lib/notifier/notify_send.rb
+++ b/lib/notifier/notify_send.rb
@@ -3,7 +3,7 @@ module Notifier
     extend self
 
     def supported?
-      Notifier.os?(/(linux|freebsd)/) && `which notify-send > /dev/null` && $? == 0
+      Notifier.os?(/(linux|freebsd)/) && `which notify-send &> /dev/null` && $? == 0
     end
 
     def notify(options)

--- a/lib/notifier/osd_cat.rb
+++ b/lib/notifier/osd_cat.rb
@@ -3,7 +3,7 @@ module Notifier
     extend self
 
     def supported?
-      Notifier.os?(/(linux|freebsd)/) && `which osd_cat > /dev/null` && $? == 0
+      Notifier.os?(/(linux|freebsd)/) && `which osd_cat &> /dev/null` && $? == 0
     end
 
     def notify(options)


### PR DESCRIPTION
kdialog, notify_send and osd_cat notifiers shell out calling the `which`
utility and redirecting standart output to /dev/null. However, when
`which` can't find a file in your $PATH, the error message is
written to standard error, causing it to be displayed when you call the
`notify` method.

This commit makes `which` redirect both its standard output and standard
error to /dev/null.