### PR TITLE
Avoiding dead threads and a little bit improvement for growl notifier

### DIFF
--- a/lib/notifier/growl.rb
+++ b/lib/notifier/growl.rb
@@ -14,10 +14,10 @@ module Notifier
       command = [
         "growlnotify",
         "--name", "test_notifier",
-        "--image", options[:image],
+        "--image", options[:image].to_s,
         "--priority", "2",
-        "--message", options[:message],
-        options[:title]
+        "--message", options[:message].to_s,
+        options[:title].to_s
       ]
 
       Thread.new { system(*command) }

--- a/lib/notifier/growl.rb
+++ b/lib/notifier/growl.rb
@@ -11,14 +11,18 @@ module Notifier
 
     def notify(options)
       register
-      command = [
-        "growlnotify",
-        "--name", "test_notifier",
-        "--image", options[:image].to_s,
-        "--priority", "2",
-        "--message", options[:message].to_s,
-        options[:title].to_s
-      ]
+      command = if options.is_a?(String)
+        "growlnotify -m '#{options}'"
+      else
+        [
+          "growlnotify",
+          "--name", "test_notifier",
+          "--image", options[:image].to_s,
+          "--priority", "2",
+          "--message", options[:message].to_s,
+          options[:title].to_s
+        ]
+      end
 
       Thread.new { system(*command) }
     end

--- a/lib/notifier/kdialog.rb
+++ b/lib/notifier/kdialog.rb
@@ -9,8 +9,8 @@ module Notifier
     def notify(options)
       command = [
         "kdialog",
-        "--title", options[:title],
-        "--passivepopup", options[:message], "5"
+        "--title", options[:title].to_s,
+        "--passivepopup", options[:message].to_s, "5"
       ]
 
       Thread.new { system(*command) }

--- a/lib/notifier/knotify.rb
+++ b/lib/notifier/knotify.rb
@@ -9,7 +9,7 @@ module Notifier
     def notify(options)
       command = [
         "dcop", "knotify", "default", "notify", "eventname",
-        options[:title], options[:message],
+        options[:title].to_s, options[:message].to_s,
         "", "", "16", "2"
       ]
 

--- a/lib/notifier/notify_send.rb
+++ b/lib/notifier/notify_send.rb
@@ -9,9 +9,9 @@ module Notifier
     def notify(options)
       command = [
         "notify-send", "-i",
-        options[:image],
-        options[:title],
-        options[:message]
+        options[:image].to_s,
+        options[:title].to_s,
+        options[:message].to_s
       ]
 
       Thread.new { system(*command) }


### PR DESCRIPTION
Hello! I want to include functionality of your gem in mine https://github.com/ruby-talks/talks, so I started to play with it and want to improve a little bit what I think will be more comfortable in usage.

1. When you send to notify method not enough options for notifier it will throw you an error because `option[:some_option]` will return `nil` and `system('bla', 'bla', nil)` will return type error. So I just add `.to_s` for each option call.

2. It will be nice that if all notifiers can just get message in notify method and show it without other options and without hash-style method call. So now we can write `Notifier.notify 'bla bla'` and if you use Growl on your machine it will show you simple notification.

Thanks! :)